### PR TITLE
typo in include

### DIFF
--- a/MQ2DanNet/MQ2DanNet.cpp
+++ b/MQ2DanNet/MQ2DanNet.cpp
@@ -38,7 +38,7 @@
 #ifdef LOCAL_BUILD
 #include <zyre.h>
 #else
-#include "..\MQ2DanNetDeps\libzyre\include\zyre.h"
+#include "..\MQ2DanNet\Deps\libzyre\include\zyre.h"
 #endif
 
 #include "../MQ2Plugin.h"


### PR DESCRIPTION
a little typo that stopped zyre.h from loading - Redbot